### PR TITLE
rebuild based on the updated FFTW libraries

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Because FFTW is statically linked, we need to update this package to get the performance gains from conda-forge/fftw-feedstock#35