### PR TITLE
Use new numpy format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,10 @@
 version: 2
 
 jobs:
-  build__CONDA_NPY_111__CONDA_PY_27:
+  build__CONDA_PY_27:
     working_directory: ~/test
     machine: true
     environment:
-      - CONDA_NPY: "111"
       - CONDA_PY: "27"
     steps:
       - checkout
@@ -19,62 +18,14 @@ jobs:
       - run:
           name: Print conda-build environment variables
           command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
             echo "CONDA_PY=${CONDA_PY}"
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_112__CONDA_PY_27:
+  build__CONDA_PY_35:
     working_directory: ~/test
     machine: true
     environment:
-      - CONDA_NPY: "112"
-      - CONDA_PY: "27"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_113__CONDA_PY_27:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "113"
-      - CONDA_PY: "27"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_111__CONDA_PY_35:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "111"
       - CONDA_PY: "35"
     steps:
       - checkout
@@ -88,62 +39,14 @@ jobs:
       - run:
           name: Print conda-build environment variables
           command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
             echo "CONDA_PY=${CONDA_PY}"
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_112__CONDA_PY_35:
+  build__CONDA_PY_36:
     working_directory: ~/test
     machine: true
     environment:
-      - CONDA_NPY: "112"
-      - CONDA_PY: "35"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_113__CONDA_PY_35:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "113"
-      - CONDA_PY: "35"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_111__CONDA_PY_36:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "111"
       - CONDA_PY: "36"
     steps:
       - checkout
@@ -157,53 +60,6 @@ jobs:
       - run:
           name: Print conda-build environment variables
           command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_112__CONDA_PY_36:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "112"
-      - CONDA_PY: "36"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_113__CONDA_PY_36:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "113"
-      - CONDA_PY: "36"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
             echo "CONDA_PY=${CONDA_PY}"
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
@@ -213,12 +69,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build__CONDA_NPY_111__CONDA_PY_27
-      - build__CONDA_NPY_112__CONDA_PY_27
-      - build__CONDA_NPY_113__CONDA_PY_27
-      - build__CONDA_NPY_111__CONDA_PY_35
-      - build__CONDA_NPY_112__CONDA_PY_35
-      - build__CONDA_NPY_113__CONDA_PY_35
-      - build__CONDA_NPY_111__CONDA_PY_36
-      - build__CONDA_NPY_112__CONDA_PY_36
-      - build__CONDA_NPY_113__CONDA_PY_36
+      - build__CONDA_PY_27
+      - build__CONDA_PY_35
+      - build__CONDA_PY_36

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,9 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_NPY=111  CONDA_PY=27
-    - CONDA_NPY=112  CONDA_PY=27
-    - CONDA_NPY=113  CONDA_PY=27
-    - CONDA_NPY=111  CONDA_PY=35
-    - CONDA_NPY=112  CONDA_PY=35
-    - CONDA_NPY=113  CONDA_PY=35
-    - CONDA_NPY=111  CONDA_PY=36
-    - CONDA_NPY=112  CONDA_PY=36
-    - CONDA_NPY=113  CONDA_PY=36
+    - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "eVmEO6bJ7nJfYJTLpUuD5PsjJbxyLDfnW7hCcZTP7GPDLWd0PERnd444FyuhjTnFLMVZt3/lvAOz/zXODwd15umLLzaF7BpZ1SrfDfqYTeA8wvjOl/QLJfVq3dU2WsGEi/HycrvmuelXU1dztzkaJ4AvGHkPdhcPVIZsQnS6U8x8RE2LJFBzfHEVPaK+h0A/5QggTKSHpHuJW+5i9IeYO60ZvcJ0uAcBiDoiCGzZ9574qcB8m67mW12ToGhAJIUVHe84pYJ8FEy19aQX5asulafd0WZ9uQs/PU9I8pj/xolA2IeYYg5OqMlfGZ3PqkFUelxSFWN+d16oXbQkybHbbKuOZsG3dar3si1g+Do1/xbpFgmDj2r51isY46QOTtClWumf/thfZwW1IQkvH7e8QosAy8aWJcml3CYIO255FH+BXmWwc/XgNJBAor69/WdPDtRyPlzj0EbMPi3Rd0/wvFsA+pLLvWgN69JNw/6dfY4X3hSlvj53Vi6L2HaUismird06AuSMbJajTI5R/ndyMkwHw3tcfsGAnCngmTQEGsvuNDyX83iMKUfvWV4rG1nuWSBmjzJvXomqsvkQWjb+yPB4pk/oeCpZxQNcMjdLYqbg5ytJ91NHn+YwozKn+hgzbpV+Bz0H+p/SJfjtW3+wLrfUG4tjQ53w+bQoDgOvHTo="

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -40,7 +40,6 @@ cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -e HOST_USER_ID="${HOST_USER_ID}" \
-                        -e CONDA_NPY="${CONDA_NPY}" \
                         -e CONDA_PY="${CONDA_PY}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,38 +3,38 @@
 {% set sha256 = "739b436b7c0aeddf99a48749380260364d2dc027cf1d5f63dafb5f50068ede1a" %}
 
 package:
-    name: {{ name|lower }}
-    version: {{ version }}
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-    fn: {{ name }}-{{ version }}.tar.gz
-    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: {{ sha256 }}
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   number: 2
   skip: True  # [win]
 
 requirements:
-    build:
-        - toolchain
-        - cython
-        - python
-        - setuptools
-        - numpy x.x
-        - fftw
-    run:
-        - python
-        - numpy x.x
+  build:
+    - toolchain
+    - cython
+    - python
+    - setuptools
+    - numpy x.x
+    - fftw
+  run:
+    - python
+    - numpy x.x
 
 about:
-    home: http://hgomersall.github.com/pyFFTW/
-    license: BSD or GPL 2
-    license_file: LICENSE.txt
-    summary: A pythonic wrapper around FFTW, the FFT library, presenting a unified interface for all the supported transforms.
+  home: http://hgomersall.github.com/pyFFTW/
+  license: BSD or GPL 2
+  license_file: LICENSE.txt
+  summary: A pythonic wrapper around FFTW, the FFT library, presenting a unified interface for all the supported transforms.
 
 extra:
-    recipe-maintainers:
-        - grlee77
-        - jakirkham
-        - jjhelmus
+  recipe-maintainers:
+    - grlee77
+    - jakirkham
+    - jjhelmus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,15 @@ requirements:
     - cython
     - python
     - setuptools
-    - numpy x.x
+    - numpy 1.8.*  # [not (win and (py35 or py36))]
+    - numpy 1.9.*  # [win and py35]
+    - numpy 1.11.*  # [win and py36]
     - fftw
   run:
     - python
-    - numpy x.x
+    - numpy >=1.8  # [not (win and (py35 or py36))]
+    - numpy >=1.9  # [win and py35]
+    - numpy >=1.11  # [win and py36]
 
 about:
   home: http://hgomersall.github.com/pyFFTW/


### PR DESCRIPTION
Switches from the old `numpy x.x` format to the new `numpy` minimum supported version format. Details can be found in the [conda-forge docs]( https://conda-forge.org/docs/meta.html#building-against-numpy ). Also some minor formatting fixes. Bumps the build number due to the `numpy` changes and to rebuild in the presence of `fftw` version `3.3.7`, which was recently released (thanks @jschueller). Feedstock is also re-rendered with `conda-smithy` 2.4.2 in the process.