### PR TITLE
restore static linking and bump the build number

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,9 @@
 
 export C_INCLUDE_PATH=$PREFIX/include  # required as fftw3.h installed here
 
+# define STATIC_FFTW_DIR so the patched setup.py will statically link FFTW
+export STATIC_FFTW_DIR=$PREFIX/lib
+
 # define PYFFTW_USE_PTHREADS so that we do not use the openmp version
 export PYFFTW_USE_PTHREADS=1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<39 and arm64]"
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
+      # only need fftw at run-time if static linking was not used
     - fftw  # [win]
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - fftw
+    - fftw  # [win]
 
 
 about:


### PR DESCRIPTION
symbol conflicts were reported again in pyFFTW/pyfftw#106 after static linking was removed in #47. This PR just restores the static linking

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
